### PR TITLE
Fix regex handling of tables with WITH storage parameters

### DIFF
--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -228,7 +228,7 @@ module ActiveRecordCleanDbStructure
       unique_constraints.each do |table, name, columns|
         dump.gsub!(/^(?<statement>CREATE TABLE #{table} \(.*?\);)/m) do
           constraint = "CONSTRAINT #{name} UNIQUE #{columns}"
-          $LAST_MATCH_INFO[:statement].sub(/\n\);\z/, ",\n    #{constraint}\n);").to_s
+          $LAST_MATCH_INFO[:statement].sub(/(\n\)(?:;|\nWITH [^\n]+;))\z/, ",\n    #{constraint}\\1").to_s
         end
       end
     end

--- a/lib/activerecord-clean-db-structure/clean_dump.rb
+++ b/lib/activerecord-clean-db-structure/clean_dump.rb
@@ -116,7 +116,7 @@ module ActiveRecordCleanDbStructure
         dump.gsub!(/^CREATE( UNIQUE)? INDEX \w+ ON .+\n+/, '')
         dump.gsub!(/^-- Name: \w+; Type: INDEX\n+/, '')
         indexes.each do |table, indexes_for_table|
-          dump.gsub!(/^(CREATE TABLE #{table}\b(:?[^;\n]*\n)+)(\);\n|PARTITION.+\);\n)/) do |match|
+          dump.gsub!(/^(CREATE TABLE #{table}\b(:?[^;\n]*\n)+)(\);\n|WITH [^\n]+;\n|PARTITION.+\);\n)/) do |match|
             match + "\n" + indexes_for_table
           end
           dump.gsub!(/^(CREATE (?:MATERIALIZED\s)?VIEW #{table}\b.*?;\n)/m) do |match|
@@ -143,7 +143,7 @@ module ActiveRecordCleanDbStructure
     # - ignores quotes which surround column names that are equal to reserved PostgreSQL names.
     # - keeps the columns at the top and places the constraints at the bottom.
     def order_column_definitions
-      dump.gsub!(/^(?<table>CREATE TABLE .+?\(\n)(?<columns>.+?)(?=\n(\);|\)\nPARTITION.+\);)$)/m) do
+      dump.gsub!(/^(?<table>CREATE TABLE .+?\(\n)(?<columns>.+?)(?=\n(\);|\)\nWITH [^\n]+;|\)\nPARTITION.+\);)$)/m) do
         table = $LAST_MATCH_INFO[:table]
         columns =
           $LAST_MATCH_INFO[:columns]

--- a/test/activerecord-clean-db-structure/storage_parameters_test.rb
+++ b/test/activerecord-clean-db-structure/storage_parameters_test.rb
@@ -1,0 +1,67 @@
+require './test/spec_helper'
+require 'activerecord-clean-db-structure/clean_dump'
+
+class StorageParametersTest < Minitest::Spec
+  described_class = ActiveRecordCleanDbStructure::CleanDump
+
+  describe 'Table with WITH storage parameters' do
+    options = {
+      indexes_after_tables: true,
+      order_column_definitions: true,
+      move_unique_constraints_to_tables: true
+    }
+
+    dump = <<~SQL
+      --
+      -- Name: invoices; Type: TABLE; Schema: public; Owner: -
+      --
+
+      CREATE TABLE public.invoices (
+        id BIGSERIAL,
+        name character varying NOT NULL,
+        created_at timestamp with time zone NOT NULL
+      )
+      WITH (autovacuum_vacuum_scale_factor='0.01', autovacuum_vacuum_threshold='1000');
+
+      --
+      -- Name: versions; Type: TABLE; Schema: public; Owner: -
+      --
+
+      CREATE TABLE public.versions (
+        id BIGSERIAL,
+        event character varying NOT NULL,
+        created_at timestamp with time zone NOT NULL
+      );
+
+      --
+      -- Name: index_invoices_on_created_at; Type: INDEX; Schema: public; Owner: -
+      --
+
+      CREATE INDEX index_invoices_on_created_at ON public.invoices USING btree (created_at);
+
+      --
+      -- Name: index_versions_on_created_at; Type: INDEX; Schema: public; Owner: -
+      --
+
+      CREATE INDEX index_versions_on_created_at ON public.versions USING btree (created_at);
+
+      --
+      -- PostgreSQL database dump complete
+      --
+    SQL
+
+    it 'places indexes after the correct tables and sorts columns without bleeding across WITH clause' do
+      result = described_class.new(dump, options).run
+      # invoices index placed after invoices table
+      assert_match(/WITH \(autovacuum_vacuum_scale_factor='0\.01', autovacuum_vacuum_threshold='1000'\);\n\nCREATE INDEX index_invoices_on_created_at/, result)
+      # versions index placed after versions table, not after invoices
+      assert_match(/CREATE TABLE public\.versions.*CREATE INDEX index_versions_on_created_at/m, result)
+      # event column not present inside the invoices CREATE TABLE block
+      invoices_block = result[/CREATE TABLE public\.invoices \(.*?\)\nWITH [^\n]+;/m]
+      refute_nil invoices_block
+      refute_match(/event character varying/, invoices_block)
+      # versions table intact
+      assert_match(/CREATE TABLE public\.versions \(\n  created_at timestamp with time zone NOT NULL,\n  event character varying NOT NULL,\n  id BIGSERIAL\n\)/, result)
+    end
+  end
+end

--- a/test/activerecord-clean-db-structure/storage_parameters_test.rb
+++ b/test/activerecord-clean-db-structure/storage_parameters_test.rb
@@ -46,6 +46,13 @@ class StorageParametersTest < Minitest::Spec
       CREATE INDEX index_versions_on_created_at ON public.versions USING btree (created_at);
 
       --
+      -- Name: invoices index_invoices_on_name_and_id; Type: CONSTRAINT; Schema: public; Owner: -
+      --
+
+      ALTER TABLE ONLY public.invoices
+        ADD CONSTRAINT index_invoices_on_name_and_id UNIQUE (name, id);
+
+      --
       -- PostgreSQL database dump complete
       --
     SQL
@@ -60,6 +67,8 @@ class StorageParametersTest < Minitest::Spec
       invoices_block = result[/CREATE TABLE public\.invoices \(.*?\)\nWITH [^\n]+;/m]
       refute_nil invoices_block
       refute_match(/event character varying/, invoices_block)
+      # unique constraint moved inline, not lost
+      assert_match(/CONSTRAINT index_invoices_on_name_and_id UNIQUE \(name, id\)/, invoices_block)
       # versions table intact
       assert_match(/CREATE TABLE public\.versions \(\n  created_at timestamp with time zone NOT NULL,\n  event character varying NOT NULL,\n  id BIGSERIAL\n\)/, result)
     end


### PR DESCRIPTION
## Problem

Tables with `WITH (...)` storage parameters (e.g. autovacuum settings) end their `CREATE TABLE` block as:

\`\`\`sql
)
WITH (autovacuum_vacuum_scale_factor='0.01', ...);
\`\`\`

Two regexes in `CleanDump` only recognized `);` as the table terminator, breaking when `WITH (...)` was present.

**Bug 1 — `indexes_after_tables`**

The end-of-table pattern `(\);\n|PARTITION.+\);\n)` didn't match `)\nWITH (...);\n`. The `)` line was consumed by the preceding `(:?[^;\n]*\n)+` group, leaving `WITH (...);\n` unmatched. Indexes were extracted and deleted from their original position but never reinserted after the table → all indexes for that table vanished from the dump.

**Bug 2 — `order_column_definitions`**

The lookahead `(?=\n(\);|\)\nPARTITION.+\);)$)` also didn't terminate at `)\nWITH (...);\n`. The lazy `(?<columns>.+?)` overshot past the storage parameters into the next `CREATE TABLE` statement, stealing its columns into the current table's column list.

## Fix

Both patterns now also accept `)\nWITH [^\n]+;` as a valid table terminator.

## Test

Added `storage_parameters_test.rb` that verifies:
- indexes are placed after the correct table (not lost)
- columns don't bleed from the next table into the one with `WITH (...)`
- the subsequent table's columns remain intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)